### PR TITLE
fix(nestjs-crud): skip CrudContextOverlay on non-CRUD controllers

### DIFF
--- a/packages/nestjs-crud/README.md
+++ b/packages/nestjs-crud/README.md
@@ -603,7 +603,7 @@ via `CrudQueryParser`.
 
 ### Multiple Filters
 
-```
+```text
 GET /photos?filter[0]=status||$eq||active&filter[1]=views||$gt||100
 ```
 
@@ -611,7 +611,7 @@ GET /photos?filter[0]=status||$eq||active&filter[1]=views||$gt||100
 
 Use dot notation to filter by related entity fields:
 
-```
+```text
 GET /photos?filter=author.name||$eq||Alice
 ```
 

--- a/packages/nestjs-crud/src/infrastructure/interceptors/__tests__/crud-context.interceptor.e2e-spec.ts
+++ b/packages/nestjs-crud/src/infrastructure/interceptors/__tests__/crud-context.interceptor.e2e-spec.ts
@@ -1,6 +1,6 @@
 import supertest from 'supertest';
 
-import { Param, ParseIntPipe, Query } from '@nestjs/common';
+import { Controller, Get, Param, ParseIntPipe, Query } from '@nestjs/common';
 import { NestApplication } from '@nestjs/core';
 import { Test } from '@nestjs/testing';
 
@@ -244,5 +244,47 @@ describe('#crud', () => {
       const res = await $.get('/test2/normal/0').expect(200);
       expect(res.body.params).toHaveProperty('id', 0);
     });
+  });
+});
+
+describe('#crud non-crud controller coexistence', () => {
+  @Controller('health')
+  class HealthController {
+    @Get()
+    check() {
+      return { status: 'ok' };
+    }
+
+    @Get('info')
+    info() {
+      return { version: '1.0.0' };
+    }
+  }
+
+  let app: NestApplication;
+
+  beforeAll(async () => {
+    const module = await Test.createTestingModule({
+      imports: [CrudModule.forRoot({})],
+      controllers: [HealthController],
+    }).compile();
+    app = module.createNestApplication();
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('should not throw CRUD_CONTEXT_ERROR on non-crud controller', async () => {
+    const res = await supertest(app.getHttpServer()).get('/health').expect(200);
+    expect(res.body).toEqual({ status: 'ok' });
+  });
+
+  it('should handle multiple routes on non-crud controller', async () => {
+    const res = await supertest(app.getHttpServer())
+      .get('/health/info')
+      .expect(200);
+    expect(res.body).toEqual({ version: '1.0.0' });
   });
 });

--- a/packages/nestjs-crud/src/infrastructure/interceptors/crud-context.overlay.ts
+++ b/packages/nestjs-crud/src/infrastructure/interceptors/crud-context.overlay.ts
@@ -111,6 +111,12 @@ export class CrudContextOverlay<
   }
 
   attach(context: ExecutionContext): void {
+    const target = context.getClass();
+    const entity = this.reflectionService.getEntity(target);
+
+    // Skip controllers without CRUD metadata (e.g. normal REST controllers)
+    if (!entity) return;
+
     const request = context.switchToHttp().getRequest();
     const ctx = getAppContext(request);
     const resolved = this.resolve(context);

--- a/packages/nestjs-invitation/README.md
+++ b/packages/nestjs-invitation/README.md
@@ -33,6 +33,7 @@ event-driven lifecycle management.
 ## Provided Features
 
 ### Invitation Lifecycle
+
 - Create invitation by user ID (with explicit code)
 - Create invitation by email address (auto-generates code, resolves user)
 - Send/resend invitation email (with OTP passcode generation)
@@ -41,6 +42,7 @@ event-driven lifecycle management.
 - Remove (hard delete) an invitation
 
 ### OTP Integration
+
 - Auto-create OTP on invitation send
 - Consume OTP on acceptance (single-use)
 - Clear all OTPs for a user+category on revocation
@@ -50,19 +52,23 @@ event-driven lifecycle management.
 - Optional rate limiting (rateSeconds + rateThreshold)
 
 ### Email Delivery
+
 - Send invitation email with passcode and expiration
 - Send acceptance confirmation email
 - Handlebars template support with configurable templates
 - Configurable sender address and base URL
 
 ### User Resolution
+
 - Look up user by ID
 - Look up user by email address
 
 ### Event-Driven Architecture
+
 - `InvitationCreatedEvent` -- fired on creation
 - `InvitationDispatchedEvent` -- fired when email should be sent (carries OTP metadata)
-- `InvitationAcceptedEvent` -- fired on acceptance (carries optional payload for downstream listeners)
+- `InvitationAcceptedEvent` -- fired on acceptance (carries optional payload
+  for downstream listeners)
 - `InvitationRevokedEvent` -- fired on revocation
 - `InvitationRemovedEvent` -- fired on deletion
 - Auto-send email on dispatch via `InvitationDispatchedListener`
@@ -70,10 +76,12 @@ event-driven lifecycle management.
 - Auto-clear OTPs on revocation via `InvitationRevokedListener`
 
 ### Auto-Revocation
+
 - On acceptance: automatically revoke all sibling invitations (same user+category)
 - On revocation: automatically clear associated OTPs
 
 ### HTTP Gateway
+
 - Create invitation endpoint (by user ID)
 - Create invitation endpoint (by email)
 - Send/resend invitation endpoint
@@ -83,6 +91,7 @@ event-driven lifecycle management.
 - Read single invitation
 
 ### Repository
+
 - Get invitation by ID
 - Find invitation by code
 - Find all invitations by user+category
@@ -92,9 +101,11 @@ event-driven lifecycle management.
 - Domain-to-persistence mapping via `InvitationMapper`
 
 ### Seeding
+
 - `InvitationFactory` for generating test invitation entities
 
 ### Configurable Settings
+
 - Email: sender address, base URL, invitation template, accepted template
 - OTP: namespace, type, expiration, clear-on-create, rate limiting
 
@@ -271,6 +282,7 @@ commands/queries through the NestJS CQRS bus.
 ### InvitationOtpPort
 
 Settings:
+
 ```ts
 interface InvitationOtpPortSettings {
   createCommand: Type<CreateOtpCommandInterface>;
@@ -290,6 +302,7 @@ interface InvitationOtpPortSettings {
 ### InvitationUserPort
 
 Settings:
+
 ```ts
 interface InvitationUserPortSettings {
   getByIdQuery: Type<GetUserByIdQueryInterface>;
@@ -302,11 +315,13 @@ interface InvitationUserPortSettings {
 | `getById` | `(ctx, userId)` | Fetch user by ID |
 | `getByEmail` | `(ctx, email)` | Fetch user by email |
 
-Returns `InvitationUserResult = (ReferenceIdInterface & InvitationUserInterface) | null`.
+Returns
+`InvitationUserResult = (ReferenceIdInterface & InvitationUserInterface) | null`.
 
 ### InvitationEmailPort
 
 Settings:
+
 ```ts
 interface InvitationEmailPortSettings {
   sendInvitationCommand: Type<SendInvitationEmailCommandInterface>;
@@ -469,7 +484,7 @@ Register the listener as a provider in your module to start receiving events.
 | `InvitationUserUndefinedException` | -- | `INVITATION_USER_UNDEFINED_ERROR` |
 | `InvitationNotAcceptedException` | 400 | `INVITATION_NOT_ACCEPTED_ERROR` |
 
-## HTTP Gateway
+## HTTP Gateway Overview
 
 The gateway layer bridges `@concepta/nestjs-crud` operations to domain
 commands and queries.
@@ -546,7 +561,7 @@ export class InvitationFeatureModule {}
 | `@concepta/nestjs-invitation` | Module, aggregate, commands, queries, events, handlers, ports, policies, DTOs, repository, mapper, exceptions |
 | `@concepta/nestjs-invitation/optional/typeorm` | `InvitationSqliteEntity`, `InvitationPostgresEntity` |
 
-## Seeding
+## Seeding and Test Factories
 
 An `InvitationFactory` is available for test seeding:
 

--- a/packages/nestjs-repository/README.md
+++ b/packages/nestjs-repository/README.md
@@ -494,7 +494,7 @@ The `OrderBy` helper builds ORM-agnostic
 `OrderClause` arrays that `RepositoryAdapter` implementations translate
 into driver-specific sort options.
 
-### Static API
+### OrderBy Static API
 
 Pass the entity type as a generic parameter on each call:
 
@@ -515,7 +515,7 @@ const users = await userRepo.find(
 );
 ```
 
-### Typed Builder API
+### OrderBy Typed Builder API
 
 Bind the entity type once with `OrderBy.for<Entity>()`. All subsequent calls
 type-check field names against the entity:
@@ -553,7 +553,7 @@ const users = await userRepo.findAndCount({
 | `asc(field)` | Ascending sort |
 | `desc(field)` | Descending sort |
 
-### Utility Methods
+### OrderBy Utility Methods
 
 | Method | Description |
 | --- | --- |
@@ -939,6 +939,7 @@ root entity and each relation instead of using SQL JOINs. Results are
 hydrated together transparently.
 
 This is useful when:
+
 - JOINs produce expensive Cartesian products
 - Relations live in different datasources
 - Precise pagination control is needed (JOINs inflate row counts)


### PR DESCRIPTION
## Summary

- CrudContextOverlay (global APP_INTERCEPTOR) was throwing `CRUD_CONTEXT_ERROR` on any controller without CRUD metadata
- Normal REST controllers could not coexist with CrudModule.forRoot({}) in the same application
- Fix: check for CRUD entity metadata before processing context — skip silently if not a CRUD controller

## Test plan

- [x] Added e2e test: plain `@Controller` with `CrudModule.forRoot({})` — verifies 200 response without errors
- [x] Existing 6 interceptor tests still pass
- [x] Verified in rockets sample-server: `/me` (MeController) now works alongside CRUD-generated `/pets` controller

🤖 Generated with [Claude Code](https://claude.com/claude-code)